### PR TITLE
Fix the href link in the logo

### DIFF
--- a/src/components/navbar.jsx
+++ b/src/components/navbar.jsx
@@ -86,7 +86,7 @@ class Navbar extends React.Component {
         id="mainNav"
       >
         <div className="container">
-          <a className="navbar-brand js-scroll" href="#page-top">
+          <a className="navbar-brand js-scroll" href="/React-Portfolio">
             <img
               id="navimg"
               src={this.state.logo}


### PR DESCRIPTION
When you click on your logo, it redirects to the `#top-page` but it redirects to **404** page.

Instead of that, I changed to `/React-Portfolio` which is your home ( base URL) page.
